### PR TITLE
Added Lycanites Integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     includedDependencies 'meldexun:ASMUtil:2.8.0@jar'
     includedDependencies 'meldexun:ConfigUtil:1.0.0@jar'
 
+    buildDependencies 'curse.maven:lycanites-mobs-224770:5750564'
     buildDependencies 'curse.maven:SpartanWeaponry-278141:3634012'
 }
 

--- a/src/main/java/meldexun/reachfix/ReachFix.java
+++ b/src/main/java/meldexun/reachfix/ReachFix.java
@@ -37,6 +37,7 @@ public class ReachFix {
 	public static final String MODID = "reachfix";
 	public static final Logger LOGGER = LogManager.getLogger(MODID);
 	public static final SimpleNetworkWrapper NETWORK = NetworkRegistry.INSTANCE.newSimpleChannel(MODID);
+	public static boolean isLycanitesMobsInstalled;
 	public static boolean isSpartanWeaponryInstalled;
 
 	@EventHandler
@@ -47,6 +48,7 @@ public class ReachFix {
 
 	@EventHandler
 	public void onFMLPostInitializationEvent(FMLPostInitializationEvent event) {
+		isLycanitesMobsInstalled = Loader.isModLoaded("lycanitesmobs");
 		isSpartanWeaponryInstalled = Loader.isModLoaded("spartanweaponry");
 	}
 

--- a/src/main/java/meldexun/reachfix/integration/LycanitesMobs.java
+++ b/src/main/java/meldexun/reachfix/integration/LycanitesMobs.java
@@ -1,0 +1,21 @@
+package meldexun.reachfix.integration;
+
+import com.lycanitesmobs.core.item.equipment.ItemEquipment;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+public class LycanitesMobs {
+
+    public static double getReachBonus(EntityPlayer player, EnumHand hand) {
+        ItemStack stack = player.getHeldItem(hand);
+        Item item = stack.getItem();
+        if(!(item instanceof ItemEquipment)){
+            return 0.0D;
+        }
+        else{
+            return ((ItemEquipment) item).getDamageRange(stack);
+        }
+    }
+}

--- a/src/main/java/meldexun/reachfix/util/ReachFixUtil.java
+++ b/src/main/java/meldexun/reachfix/util/ReachFixUtil.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import meldexun.reachfix.ReachFix;
 import meldexun.reachfix.config.ReachFixConfig;
+import meldexun.reachfix.integration.LycanitesMobs;
 import meldexun.reachfix.integration.SpartanWeaponry;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.IAttributeInstance;
@@ -38,6 +39,9 @@ public class ReachFixUtil {
 			reach += config.entityReachCreative - config.reachCreative;
 		} else {
 			reach += config.entityReach - config.reach;
+		}
+		if (ReachFix.isLycanitesMobsInstalled) {
+			reach += LycanitesMobs.getReachBonus(player, hand);
 		}
 		if (ReachFix.isSpartanWeaponryInstalled) {
 			reach += SpartanWeaponry.getReachBonus(player, hand);


### PR DESCRIPTION
Added Lycanites Integration modeled after existing SpartanWeaponry integration.

Standalone would only affect attack reach and does not affect sweep AOE range.
With RLCombat this reach value can be referenced to replicate how LycanitesMobs scales sweeping AOE range.